### PR TITLE
Improve Travis CI setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ language: php
 
 php:
   - 7.3
+  - 7.4
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer update --prefer-source --no-interaction --dev
+  - travis_retry composer update --prefer-source --no-interaction
 
 script:
   - vendor/bin/phpunit -v --coverage-text --colors=never --stderr


### PR DESCRIPTION
# Changed log

- Add `php-7.4` version test during Travis CI build.
- Removing the `--dev` option for `composer update --prefer-source --no-interaction` command because the deprecated message is as follows:

```
dYou are using the deprecated option "--dev". It has no effect and will break in Composer 3.
```